### PR TITLE
feat: ページ番号のサイズを大・中・小の三段階で設定可能にする

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,6 +38,7 @@ function App() {
   const [draggedFile, setDraggedFile] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
   const [pageNumberPosition, setPageNumberPosition] = useState<'bottom' | 'top'>('bottom');
+  const [pageNumberSize, setPageNumberSize] = useState<'small' | 'medium' | 'large'>('medium');
   const [isProcessing, setIsProcessing] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
 
@@ -261,10 +262,28 @@ function App() {
                   pageNumberText = `${pageNumber} ページ`;
                   break;
               }
+              
+              // ページ番号のサイズを設定
+              let fontSize = 10; // デフォルト（中）
+              switch (pageNumberSize) {
+                case 'small':
+                  fontSize = 8;
+                  break;
+                case 'medium':
+                  fontSize = 10;
+                  break;
+                case 'large':
+                  fontSize = 14;
+                  break;
+              }
+              
+              // ページ番号の位置を設定
+              const yPosition = pageNumberPosition === 'top' ? height - 30 : 20;
+              
               page.drawText(pageNumberText, {
                 x: width / 2 - 10,
-                y: 20,
-                size: 10,
+                y: yPosition,
+                size: fontSize,
                 font: customFont,
                 color: rgb(0, 0, 0),
               });
@@ -546,6 +565,20 @@ function App() {
                     <option value="number">数字のみ</option>
                     <option value="dash">- n -</option>
                     <option value="page">n ページ</option>
+                  </select>
+                </div>
+                <div className="flex-1">
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    ページ番号のサイズ
+                  </label>
+                  <select
+                    value={pageNumberSize}
+                    onChange={(e: ChangeEvent<HTMLSelectElement>) => setPageNumberSize(e.target.value as 'small' | 'medium' | 'large')}
+                    className="block w-full sm:w-48 rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500"
+                  >
+                    <option value="small">小</option>
+                    <option value="medium">中</option>
+                    <option value="large">大</option>
                   </select>
                 </div>
               </div>


### PR DESCRIPTION
## 📋 概要
ページ番号のサイズを大・中・小の三段階で設定できる機能を追加しました。

## ✨ 追加機能
- **ページ番号サイズの三段階設定**
  - 小: 8ポイント
  - 中: 10ポイント（デフォルト）
  - 大: 14ポイント

## 🔧 実装内容
1. **状態管理の追加**
   - `pageNumberSize` ステートを追加
   - `'small' | 'medium' | 'large'` の型定義

2. **UI要素の追加**
   - ステップ2「ページ番号設定」セクションにサイズ選択セレクトボックスを追加
   - 既存のフォーマット・位置設定と並んで配置

3. **PDF描画ロジックの改善**
   - ページ番号描画時にサイズを動的に設定
   - 位置設定（上部・下部）も同時に適用されるよう改善

## 🎯 ユーザーメリット
- より細かいページ番号のカスタマイズが可能
- 資料の性質に応じて適切なサイズの選択が可能
- 既存機能（フォーマット・位置）との組み合わせでより柔軟な設定

## 🧪 テスト方法
1. PDFファイルをアップロード
2. ページ番号設定でサイズを「小」「中」「大」から選択
3. PDF結合・生成を実行
4. 生成されたPDFでページ番号のサイズが反映されているか確認

## 📝 その他
- 既存機能に影響なし
- レスポンシブデザインに対応
- 日本語UI（「小」「中」「大」）で直感的

---

ブランチ：`feature/page-number-size-options` を `main` にマージをお願いします。