### PR TITLE
総会資料メーカー2 への案内バナーとリンクを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,9 @@
     </script>
     <% } %>
     
+    <!-- 新バージョン -->
+    <link rel="related" href="https://wadatch.github.io/sokai-siryo-maker2/" title="総会資料メーカー2" />
+
     <!-- SEO対策 -->
     <title>PDF結合 無料【PTA総会資料メーカー】完全ブラウザ完結・安全なPDF結合ツール</title>
     <meta name="description" content="PTA総会資料メーカーは完全無料で安全なPDF結合ツール。ブラウザ完結でサーバーアップロード不要、プライバシー完全保護。PTA総会資料作成に最適。ページ番号・議案番号の自動追加機能付き。" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -434,6 +434,22 @@ function App() {
         </div>
       </header>
 
+      {/* 新バージョンの案内 */}
+      <section className="bg-indigo-600 text-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4 text-sm">
+          <p className="flex-1">
+            <strong>新バージョン「総会資料メーカー2」を公開しました。</strong>
+            PDFをページ単位で並べ替え・回転でき、ヘッダー・フッターの自由設定、ページごとのページ番号設定、パスワード保護、BIZ UDフォントに対応しています。このページ（初代）も引き続きご利用いただけます。
+          </p>
+          <a
+            href="https://wadatch.github.io/sokai-siryo-maker2/"
+            className="inline-flex items-center justify-center whitespace-nowrap rounded-md bg-white px-4 py-2 font-semibold text-indigo-700 shadow-sm hover:bg-indigo-50"
+          >
+            総会資料メーカー2 を使ってみる →
+          </a>
+        </div>
+      </section>
+
       {/* サイト機能説明セクション */}
       <section className="bg-blue-50 border-b border-blue-100">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">


### PR DESCRIPTION
## 概要
新バージョン [総会資料メーカー2](https://wadatch.github.io/sokai-siryo-maker2/) への案内バナーをヘッダー直下に追加し、`index.html` に関連リンクを追加します。

- 初代の機能・UIはそのまま（バナーの追加のみ）
- 目的: 利用者への新版案内と、新版への内部リンク（SEO）

🤖 Generated with [Claude Code](https://claude.com/claude-code)